### PR TITLE
[fix] remove unnecessary wrapper from axios payload

### DIFF
--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -22,7 +22,10 @@ class _ApiClient {
         directUrl,
         handleProgress,
       } = {}) => {
-        const requestConfig = {};
+        const requestConfig = {
+          method,
+          url: formatUrl(path, directUrl)
+        };
 
         if (params) {
           requestConfig.params = { ...params };
@@ -50,7 +53,7 @@ class _ApiClient {
           requestConfig.onUploadProgress = handleProgress;
         }
 
-        return axios[method](formatUrl(path, directUrl), {
+        return axios({
           ...requestConfig,
         });
       };


### PR DESCRIPTION
Switches the axios implementation to use the full api format instead of the method aliases. The previous implementation was adding an unnecessary `data` wrapper object to the payload.

Previous payload:
```
{
  data: {
    foo: “bar”
  }
}
```

New payload:
```
{
  foo: “bar”
}
```